### PR TITLE
Add transparency setting, fix spelling and menu

### DIFF
--- a/CompassMaintenance/CompassMaintenance.lua
+++ b/CompassMaintenance/CompassMaintenance.lua
@@ -13,7 +13,17 @@ function COMSavedVariables()                                                    
         Point = 9,
         RPoint = 9,
         Lock = true,
+        Alpha = 1,
     })
+end
+--
+function UpdateCompassTransparency(val)
+    local compass_center = WINDOW_MANAGER:GetControlByName("ZO_CompassFrame", "Center")
+    local compass_left = WINDOW_MANAGER:GetControlByName("ZO_CompassFrame", "Left")
+    local compass_right = WINDOW_MANAGER:GetControlByName("ZO_CompassFrame", "Right")
+    compass_center:SetAlpha(val)
+    compass_left:SetAlpha(val)
+    compass_right:SetAlpha(val)
 end
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------
 function COMFramesUpdate()
@@ -24,7 +34,9 @@ function COMFramesUpdate()
         ZO_CompassFrameLeft:SetDimensions(10,COMSaved.Height)
         ZO_CompassFrameRight:SetDimensions(10,COMSaved.Height)
         ZO_CompassFrame:SetDimensions(COMSaved.Width,COMSaved.Height)
-        
+
+        UpdateCompassTransparency(COMSaved.Alpha)
+
        -- ZO_CompassFrame:RefreshVisible() 
         --ZO_CompassFrame:SetHeight(height)
         --ZO_CompassFrameRight:SetHeight(height)
@@ -66,6 +78,9 @@ function COMDefaultCompass()                                                    
     ZO_CompassFrameLeft:SetDimensions(10,35)
     ZO_CompassFrameRight:SetDimensions(10,35)
     ZO_CompassFrame:SetDimensions(650,35)
+
+    UpdateCompassTransparency(COMSaved.Alpha)
+
 end
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------
 function COMUpdateVars()                                                                                                -- Screen Position Update Function For Save Vars

--- a/CompassMaintenance/CompassMaintenanceMenu.lua
+++ b/CompassMaintenance/CompassMaintenanceMenu.lua
@@ -18,56 +18,76 @@ function CPMLAM2Panel()
         [1] =
         {
             type = "description",
-            text = "Simple Addon To Move and Size The Compass.",
+            text = "Addon to customize the compass",
         },
         [2] = 
         {
             type = "checkbox",
-            name = "CompassMaintenance On/Off.",
-            tooltip = "Toggle Overall Addon CompassMaintenance On/Off.",
+            name = "Addon enabled",
+            tooltip = "Toggle if the addon is enabled",
             getFunc = function() return COMSaved.Toggle end,
             setFunc = function(value) COMSaved.Toggle = value COMFramesUpdate() COMAdjustCompass() end,
         },
         [3] = 
         {
             type = "checkbox",
-            name = "CompassMaintenance Lock On/Off.",
-            tooltip = "Toggle Compass Lock On/Off.",
+            name = "Compass lock",
+            tooltip = "Toggle compass lock",
             getFunc = function() return COMSaved.Lock end,
             setFunc = function(value) COMSaved.Lock = value COMAdjustCompass() end,
         },
         [4] = 
         {
-            type = "editbox",
-            name = "Compass Scale.",
-            tooltip = "Edit Scale Of Compass, UIDefault is 1 (Patch 1.2.3 Caused Scaleing Bugs :S)",
+            type = "slider",
+            name = "Compass icon scale",
+            tooltip = "Edit compass scale (due to a bug, cannot go over 1)",
             getFunc = function() return COMSaved.Scale end,
             setFunc = function(Scale) COMSaved.Scale = tonumber(Scale) COMFramesUpdate() end,
+            min = 0,
+            max = 1,
+            step = 0.01,
+            decimals = 2,
         },
         [5] = 
         {
             type = "editbox",
-            name = "Compass Height.",
-            tooltip = "Edit Height Of Compass",
+            name = "Compass height in pixels",
+            tooltip = "Edit height of the compass",
             getFunc = function() return COMSaved.Height end,
             setFunc = function(Height) COMSaved.Height = tonumber(Height) COMFramesUpdate() end,
         },
         [6] = 
         {
             type = "editbox",
-            name = "Compass Width.",
-            tooltip = "Edit Width Of Compass, UIDefault is 1",
+            name = "Compass width in pixels",
+            tooltip = "Edit width of the compass",
             getFunc = function() return COMSaved.Width end,
             setFunc = function(Width) COMSaved.Width = tonumber(Width) COMFramesUpdate() end,
         },
         [7] = 
         {
-            type = "editbox",
-            name = "Compass Center Pin Text Scale.",
-            tooltip = "Edit Compass Center Pin Text Scale On/Off.",
+            type = "slider",
+            name = "Compass center pin text scale",
+            tooltip = "Edit compass center pin text scale",
             getFunc = function() return COMSaved.TextScale end,
             setFunc = function(TextScale) COMSaved.TextScale = tonumber(TextScale) COMFramesUpdate() end,
+            min = 0,
+            max = 3,
+            step = 0.1,
+            decimals = 1,
         },
+        [8] = 
+        {
+            type = "slider",
+            name = "Compass background transparency",
+            tooltop = "Edit compass background transparency",
+            getFunc = function() return COMSaved.Alpha end,
+            setFunc = function(value) COMSaved.Alpha = tonumber(value) COMFramesUpdate() end,
+            min = 0,
+            max = 1,
+            step = 0.1,
+            decimals = 1,
+        }
     }   
     LAM2:RegisterAddonPanel(PanelTitle.."LAM2Options", PanelData)
     LAM2:RegisterOptionControls(PanelTitle.."LAM2Options", OptionsData)


### PR DESCRIPTION
- transparency can now be set with a slider in LAM menu
- spelling has been changed, so it's more user-friendly and descriptive
- menu have been overhauled, so things that should be sliders are now
sliders with generous amount of scaling